### PR TITLE
added asset api support resolves #8

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = function(config) {
 
     return {
         jobs: require('./lib/jobs')(config),
-        cluster: require('./lib/cluster')(config)
+        cluster: require('./lib/cluster')(config),
+        assets: require('./lib/assets')(config)
     }
 };

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function(config) {
+    var request = require('./request')(config);
+    var isStream = true;
+    
+    function postAsset(stream) {
+        return request.post('/assets', stream , isStream)
+    }
+
+    function deleteAsset(id) {
+        return request.delete(`/assets/${id}`);
+    }
+
+    return {
+        post: postAsset,
+        delete: deleteAsset
+    }
+};

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Promise = require('bluebird');
 var request = require('request-promise');
 
 module.exports = function(config) {
@@ -18,13 +17,15 @@ module.exports = function(config) {
         });
     }
 
-    function post(path, record) {
-        return request({
+    function post(path, record, isStream) {
+        var config = {
             method: 'POST',
             uri: teraslice_host + path,
-            body: record,
-            json: true // Automatically stringifies the body to JSON
-        });
+            body: record
+        };
+
+        if (!isStream) config.json = true;
+        return request(config);
     }
 
 


### PR DESCRIPTION
Example on how to use:

```
// client is just however the integration tests exposes the client
var client = require('./index')({});
var fs = require('fs');

var testStream = fs.createReadStream('/path/to/zip.zip');

client.assets.post(testStream)
    .then(results => console.log('results', results )
    .catch(error => console.log('error', error))*/

// results would be  => {"_id":"668e80dbf4bb6b8bdac870db9525976e7c6d02a0"}

// pass in the client id
client.assets.delete('668e80dbf4bb6b8bdac870db9525976e7c6d02a0')
    .then(results => console.log('results', results))
    .catch(error => console.log('error', error))

// delete will also return  => {"_id":"668e80dbf4bb6b8bdac870db9525976e7c6d02a0"}
```